### PR TITLE
Fixed Broken Link and changed command ot python wsgi.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,11 @@ pip-log.txt
 .tox
 
 #Virualenv folder
+silpa
 venv
+
+#modules
+modules
 
 #editor files
 ~*

--- a/README
+++ b/README
@@ -125,7 +125,7 @@ The following modules are available for SILPA:
 * [Chardetails](https://github.com/Project-SILPA/chardetails)
 * [Payyans](https://github.com/Project-SILPA/payyans)
 * [Text Similarity](https://github.com/Project-SILPA/text-similarity)
-* [N Gram](https://github.com/Project-SILPA/indicgram)
+* [N Gram](https://github.com/Project-SILPA/indicngram)
 * [Silpa Sort](https://github.com/Project-SILPA/ucasort)
 * [Indic Stemmer](https://github.com/Project-SILPA/indicstemmer)
 * [Katpayadi Numbers](https://github.com/Project-SILPA/Katapayadi)
@@ -143,13 +143,13 @@ other modules.
 mkdir modules
 cd modules
 git clone git@github.com:Project-SILPA/Soundex.git
-cd Soundex
+cd soundex
 python setup.py install
 ```
 
 Now you can start SILPA by running
 ```shell
-$ python silpa.py
+$ python wsgi.py
 ```
 You can access SILPA at http://localhost:5000
 


### PR DESCRIPTION
#32 I've fixed the broken link to indicngram module in README. Since silpa.py has been replaced by wsgi.py, I also changed the command to python wsgi.py.